### PR TITLE
Fix CLI help text

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,7 @@ const cli = meow(`
     Usage
       $ ethereum_private_key_to_address <private-key>
 
- git@github.com:miguelmota/ethereum-private-key-to-public-key.git   Examples
+    Examples
       $ ethereum_private_key_to_address 4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d
       0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1
 `, {


### PR DESCRIPTION
## Summary
- remove stray repository link from CLI usage text

## Testing
- `npm test` *(fails: tape not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487ad2d3b08320b1fe99c9ebf42ff2