### PR TITLE
Fix cli exit timing

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -40,6 +40,7 @@ function run() {
     process.exit(1)
   }
 
-  process.stdout.write(privateKeyToAddress(privateKey))
-  process.exit(0)
+  process.stdout.write(privateKeyToAddress(privateKey) + '\n', () => {
+    process.exit(0)
+  })
 }


### PR DESCRIPTION
## Summary
- wait until stdout finishes writing before exiting

## Testing
- `node cli.js 4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d` *(fails: Cannot find module 'meow')*
- `npm test` *(fails: tape not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487caa63388320ab1fd35412145667